### PR TITLE
Interactive opercmd demo

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -15,3 +15,4 @@ There are also longer scripts that can be useful:
 |[zcx_versions.py](zcx_versions.py)|Check running zCX instances to see if any can be upgraded.|
 |[smpe_list.py](smpe_list.py)|Sample code showing how to convert from JCL to Python using the list feature of SMPE.|
 |[SMPElistDefaults.yaml](SMPElistDefaults.yaml)|Definitions that smpe_list.py needs. Must be put in the same directory as smpe_list.py. Changes need to be made to match users system|
+|[console.sh](console.sh)|Run opercmd interactively| 

--- a/samples/console.sh
+++ b/samples/console.sh
@@ -3,7 +3,7 @@
 # Create a Unix-style interactive shell for MVS, SDSF
 # or subsystem commands. Adjust $ssid to handle prefixes.
 #
-# Usage: 
+# Usage:
 #
 #     ./console.sh       - start an opercmd console
 #
@@ -11,22 +11,22 @@
 #
 # Example:
 #
-#     ./console.sh MQ01     
+#     ./console.sh MQ01
 #      !MQ01> START QMGR
 #
 # Copyright IBM Corp. 2021
 #
 
-if [ -z "$1" ]            
-then                      
-    prefix="opercmd"      
-else                      
-    prefix="$1"           
-    ssid="!$1"  # Replace prefix with your SSID prefix           
-fi                        
-                          
-while true                
-do                        
-    read -p "$prefix:> "  
-    opercmd ${ssid} $REPLY
-done         
+if [ -z "$1" ]
+then
+    prefix="opercmd"
+else
+    prefix="$1"
+    ssid="!$1"  # Replace prefix with your SSID prefix
+fi
+
+while true
+do
+    read -p "$prefix:> "
+    opercmd "${ssid} $REPLY"
+done

--- a/samples/console.sh
+++ b/samples/console.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Create a Unix-style interactive shell for MVS, SDSF
+# or subsystem commands. Adjust $ssid to handle prefixes.
+#
+# Usage: 
+#
+#     ./console.sh       - start an opercmd console
+#
+#     ./console.sh SSID  - start a console for a subsystem
+#
+# Example:
+#
+#     ./console.sh MQ01     
+#      !MQ01> START QMGR
+#
+# Copyright IBM Corp. 2021
+#
+
+if [ -z "$1" ]            
+then                      
+    prefix="opercmd"      
+else                      
+    prefix="$1"           
+    ssid="!$1"  # Replace prefix with your SSID prefix           
+fi                        
+                          
+while true                
+do                        
+    read -p "$prefix:> "  
+    opercmd ${ssid} $REPLY
+done         


### PR DESCRIPTION
Based on an internal conversation about how it would be handy for an interactive experience with opercmd.

This script is a simple demo that allows you to start a session with opercmd, optionally providing a subsystem ID to prevent repetitive typing if, like me, you do lots of commands with one subsystem.

## Usage example: 

```sh
$ console.sh
opercmd:> d iplinfo
IEE254I  11.40.07 IPLINFO DISPLAY 193
 SYSTEM IPLED AT 07.04.09 ON 09/03/2021
 RELEASE z/OS 02.04.00    LICENSE = z/OS
 USED LOADP5 IN SYS1.PARMLIB ON 062A2
 ARCHLVL = 2   MTLSHARE = N
 IEASYM LIST = (00,4A)
 IEASYS LIST = (4A) (OP)
 IODF DEVICE: ORIGINAL(062A2) CURRENT(062A2)
 IPL DEVICE: ORIGINAL(062AD) CURRENT(062AD) VOLUME(P5SY12)

opercmd:> d t
IEE136I LOCAL: TIME=11.45.43 DATE=2021.266  UTC: TIME=10.45.43 DATE=2021.266
```
